### PR TITLE
:simple_smile: First implementation of BA1999 section 3 and 3.1 :star:

### DIFF
--- a/ba1999demo.m
+++ b/ba1999demo.m
@@ -28,7 +28,11 @@ close all
 disp 'Demonstration of Bland-Altman analysis'
 
 %% load data
-% Table 1 from the article
+% add data folder to path
+pth = fileparts(mfilename('fullpath'));
+addpath(fullfile(pth,'ba1999data'))
+
+% load Table 1 (article p. 137-8)
 load bpdata
 
 n = BPData(:,1); % subject number
@@ -39,6 +43,8 @@ JName = 'Systolic BP, Observer J (mmHg)';
 SName = 'Systolic BP, Machine S (mmHg)';
 
 %% 2 Limits of agreement (article page 136)
+disp 'Section 2 Limits of agreement'
+
 % This section only considers the first observations by J and S.
 J1 = J(:,1);
 S1 = S(:,1);
@@ -67,11 +73,14 @@ display(muD) % article: -14.9 mmHg
 display(loa) % article: [-43.6, 15.0] mmHg
 
 %% 2.1 Graphical presentation of agreement (article page 140)
+disp 'Section 2.1 Graphical presentation of agreement'
+
 % If any other figures exist, the numbers below might not be correct. This
 % script was written with all other figures closed.
 % Figure 1 corresponds to article figure 1, figure 2 corresponds to article
 % figure 2.
-s = ba(figures(2), J1,S1, 'XName',JName, 'YName',SName, 'PlotAll',true);
+f = figures(2);
+s = ba(f, J1,S1, 'XName',JName, 'YName',SName, 'PlotAll',true);
 rSMuD = s.rSMuD;
 % Article: 0.07 (p. 140), here -0.03, so an error exists either here or in
 % the article.
@@ -82,7 +91,14 @@ display(rSMuD); % Spearman rank correlation between mean and difference
 ba(figure, J1,S1, 'XName',JName, 'YName',SName, ...
     'PlotMeanDifference',true, 'PlotStatistics','basic')
 
+% some text output
+f = [f;gcf];
+fn = sort([f.Number]);
+disp(['See also figures [' num2str(fn) '].'])
+
 %% 2.2 Precision of the estimated limits of agreement (article page 141)
+disp 'Section 2.2 Precision of the estimated limits of agreement'
+
 clf % Clear figure 3 and recreate it with additional confidence intervals
 % (not shown in article).
 s = ba(gcf, J1,S1, 'XName',JName, 'YName',SName, ...
@@ -96,5 +112,86 @@ display(loaCI)
 % article muDCI (p. 142): [-20.5 -12.1]
 display(muDCI)
 
-%% 3 Relationship between difference and magnitude
-%TODO
+% some text output
+f = gcf;
+fn = f.Number;
+disp(['See also figure ' num2str(fn) '.'])
+
+%% 3 Relationship between difference and magnitude (article p. 142)
+disp 'Section 3 Relationship between difference and magnitude'
+
+% load data from Table 2 in the article
+load pvdata
+
+n = PVData(:,1);
+Nadler = PVData(:,2);
+Hurley = PVData(:,3);
+
+% create figures 4a and 4b in the article
+f = figure;
+ax(1) = subplot(1,2,1);
+ax(2) = subplot(1,2,2);
+% The following could be accomplished with one line of code, but the
+% graphs in the article are constructed a bit differently, so here we
+% create the graphs accordingly, but need to do it with two separate lines.
+ba(ax(1), Hurley,Nadler, ...
+    'XName','Plasma volume (Hurley) (%)', ...
+    'YName','Plasma volume (Nadler) (%)', ...
+    'PlotCorrelation',true)
+ba(ax(2), Nadler,Hurley, ...
+    'XName','Plasma volume (Nadler) (%)', ...
+    'YName','Plasma volume (Hurley) (%)', ...
+    'PlotMeanDifference',true)
+% In one line of code it would have been:
+% ba(ax, Hurley,Nadler, 'PlotAll',true)
+% But figure 4b has the vertical axis flipped, so this does not work.
+
+% some text output
+fn = f.Number;
+disp(['See also figure ' num2str(fn) '.'])
+
+%% 3.1 Logarithmic transformation (article p. 143)
+disp 'Section 3.1 Logarithmic transformation'
+
+% perform BAA using log transformation
+f = figure;
+ax(1) = subplot(1,2,1);
+ax(2) = subplot(1,2,2);
+ba(ax(1), Hurley,Nadler, ...
+    'XName','Log plasma volume (Hurley)', ...
+    'YName','Log plasma volume (Nadler)', ...
+    'PlotCorrelation',true, 'Transform',@log)
+s = ba(ax(2), Nadler,Hurley, ...
+    'XName','Log plasma volume (Hurley)', ...
+    'YName','Log plasma volume (Nadler)', ...
+    'PlotMeanDifference',true, ...
+    'PlotStatistics','basic', ...
+    'Transform',@log);
+logMuD = s.muD;
+display(logMuD) % article: 0.099
+logLoa = s.loa;
+display(logLoa) % article: [0.056, 0.141]
+logLoaCI = s.loaCI;
+lowerLogLoaCI = logLoaCI(:,1); % lower LOA CI
+display(lowerLogLoaCI) % article [0.049, 0.064]
+
+% backtransformation of results
+muD = exp(logMuD);
+display(muD) % article: 1.11
+loa = exp(logLoa);
+display(loa) % article: [1.06, 1.15]
+
+% ratio mean-difference plot
+ba(figure, Nadler,Hurley, ...
+    'XName','Plasma volume (Nadler) (%)', ...
+    'YName','Plasma volume (Hurley) (%)', ...
+    'PlotMeanDifference',true, 'PlotStatistics','basic', ...
+    'Transform','ratio' );
+
+% some text output
+f = [f;gcf];
+fn = sort([f.Number]);
+disp(['See also figures [' num2str(fn) '].'])
+
+%% 3.2 A regression approach for nonuniform differences (article p. 145)
+disp 'Section 3.2 A regression approach for nonuniform differences'


### PR DESCRIPTION
Changes:
- ba1999demo.m
  - ba1999data folder is now automatically added to the MATLAB path.
  - every demo section displays some more text, introducing the section and indicating which figures show the results
  - added the calculations and figures from BA1999 section 3 and 3.1
- ba.m
  - added `'Transform'` name-value pair argument to allow transformation of data with a specified function (e.g. `@log`) or a different argument (e.g. `'ratio'` for a mean-ratio plot instead of mean-difference)
- private/baloa.m
  - added support for the mean-ratio plot instead of mean-difference
  - removed the forced tight and equal axes of the mean-difference plot, because they can easily result in too much whitespace
  - fixed the line of equality being barely visible when it lays on the y-limit of the axes
  - the line of equality now is `y=0` for the mean-difference plot (as before) and `y=1` for the mean-ratio plot (new feature)
  - adjusted many strings to show `'R'` instead of `'d'` in the mean-ratio plot
  - fixed a bug where the title of the mean-difference plot could be partially outside the visible figure area; now the axes height is adjusted if the title was partially invisible, such that it fits exactly right
